### PR TITLE
Replace eval_ex with the exath_engine math engine plugin

### DIFF
--- a/lib/Pages/calc_page.dart
+++ b/lib/Pages/calc_page.dart
@@ -1,5 +1,4 @@
-import 'dart:math';
-import 'package:eval_ex/expression.dart';
+import 'package:exath_engine/exath_engine.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -189,6 +188,10 @@ class _CalcPageState extends ConsumerState<CalcPage>
     _rawToFormattedPositionMap = {};
 
     _loadHistory();
+
+    // Warm up the native/wasm exath engine. No-op on native; awaits the wasm
+    // module on web so the first keystroke doesn't race initialization.
+    ensureInitialized();
   }
 
   @override
@@ -327,173 +330,52 @@ class _CalcPageState extends ConsumerState<CalcPage>
         return;
       }
 
-      // IMPORTANT: Remove commas from the expression before evaluation
-      String expressionWithoutCommas = expression.replaceAll(',', '');
-
-      // Handle inverse trig functions in degree mode
-      String preparedExpression = expressionWithoutCommas;
-
+      // Percentage handling stays app-side (context-dependent: "200+10%" etc.)
       if (expression.contains('%')) {
         try {
-          // Replace percentages with their decimal equivalents based on context
           expression = _handlePercentageCalculations(expression);
-          preparedExpression = expression.replaceAll(',', '');
           debugPrint("Expression after percentage handling: '$expression'");
         } catch (e) {
           debugPrint("Error handling percentages: $e");
-          // Continue with original expression if percentage handling fails
         }
       }
 
-      if (isDeg && isShift && expression.contains('⁻¹')) {
-        // Find all inverse trig functions in the expression
-        RegExp inverseTrigPattern =
-            RegExp(r'(sin|cos|tan)⁻¹\s*\(\s*([^()]+)\s*\)');
-        Iterable<RegExpMatch> matches =
-            inverseTrigPattern.allMatches(expression);
-
-        // Process each match
-        for (RegExpMatch match in matches) {
-          String fullMatch = match.group(0)!;
-          String funcType = match.group(1)!;
-          String argExpr = match.group(2)!;
-
-          debugPrint(
-              "Found inverse trig function: $fullMatch, type: $funcType, arg: $argExpr");
-
-          // Prepare the argument expression
-          String preparedArgExpr = argExpr
-              .replaceAll('×', '*')
-              .replaceAll('÷', '/')
-              .replaceAll('π', '3.141592653589793')
-              .replaceAllMapped(
-                  RegExp(r'(?<![\d.])e'), (m) => '2.718281828459045');
-
-          // Evaluate the argument
-          try {
-            Expression argExpression = Expression(preparedArgExpr);
-            var argResult = argExpression.eval();
-
-            if (argResult != null) {
-              double argValue = argResult.toDouble();
-              double resultInRadians;
-
-              // Apply the appropriate inverse trig function
-              switch (funcType) {
-                case "sin":
-                  resultInRadians = asin(argValue);
-                  break;
-                case "cos":
-                  resultInRadians = acos(argValue);
-                  break;
-                case "tan":
-                  resultInRadians = atan(argValue);
-                  break;
-                default:
-                  throw Exception("Unknown inverse trig function");
-              }
-
-              // Convert from radians to degrees
-              double resultInDegrees = resultInRadians * (180 / pi);
-              debugPrint(
-                  "Calculated $funcType⁻¹($argValue) = $resultInDegrees degrees");
-
-              // Replace the inverse trig function with its numeric result
-              preparedExpression = preparedExpression.replaceFirst(
-                  fullMatch, resultInDegrees.toString());
-
-              debugPrint("Expression after substitution: $preparedExpression");
-            }
-          } catch (e) {
-            debugPrint("Error evaluating inverse trig argument: $e");
-            // If we can't evaluate this part, continue with the original expression
-          }
-        }
-      }
-
-      // Now process the expression with substituted values
-      preparedExpression = preparedExpression
+      // Map Pro Calc's display glyphs to exath syntax. The engine natively
+      // handles angle mode (DEG/RAD), the constants π and e, trig & inverse
+      // trig, sqrt, ln, log (base-10), factorial (!) and powers (^), so the
+      // old SINR/COSR variants and manual degree conversion are gone.
+      final String preparedExpression = expression
+          .replaceAll(',', '')
           .replaceAll('×', '*')
           .replaceAll('÷', '/')
-          .replaceAll('π', '3.141592653589793')
-          .replaceAllMapped(
-              RegExp(r'(?<![\d.])e'), (match) => '2.718281828459045');
+          .replaceAll('√', 'sqrt')
+          .replaceAll('sin⁻¹', 'asin')
+          .replaceAll('cos⁻¹', 'acos')
+          .replaceAll('tan⁻¹', 'atan');
 
-      // Handle remaining trig functions
-      if (isShift) {
-        if (isDeg) {
-          preparedExpression = preparedExpression
-              .replaceAll('sin⁻¹(', 'ASIN(')
-              .replaceAll('cos⁻¹(', 'ACOS(')
-              .replaceAll('tan⁻¹(', 'ATAN(');
-        } else {
-          preparedExpression = preparedExpression
-              .replaceAll('sin⁻¹(', 'ASINR(')
-              .replaceAll('cos⁻¹(', 'ACOSR(')
-              .replaceAll('tan⁻¹(', 'ATANR(');
-        }
-      } else {
-        if (isDeg) {
-          preparedExpression = preparedExpression
-              .replaceAllMapped(RegExp(r'sin\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'SIN(${match.group(1)})')
-              .replaceAllMapped(RegExp(r'cos\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'COS(${match.group(1)})')
-              .replaceAllMapped(RegExp(r'tan\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'TAN(${match.group(1)})');
-        } else {
-          preparedExpression = preparedExpression
-              .replaceAllMapped(RegExp(r'sin\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'SINR(${match.group(1)})')
-              .replaceAllMapped(RegExp(r'cos\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'COSR(${match.group(1)})')
-              .replaceAllMapped(RegExp(r'tan\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-                  (match) => 'TANR(${match.group(1)})');
-        }
-      }
-
-      // Handle sqrt and logarithms
-      // Handle sqrt and logarithms
-      // Handle sqrt and logarithms
-      preparedExpression = preparedExpression
-          .replaceAllMapped(RegExp(r'√\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-              (match) => 'SQRT(${match.group(1)})')
-          .replaceAllMapped(
-              RegExp(r'ln\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-              (match) =>
-                  'LOG(${match.group(1)})') // Use LOG for natural logarithm
-          .replaceAllMapped(
-              RegExp(r'log\s*\(((?:[^()]*|\([^()]*\))*)\)'),
-              (match) =>
-                  'LOG10(${match.group(1)})'); // Use LOG10 for base-10 logarithm
-
-      debugPrint("Final expression for evaluation: '$preparedExpression'");
-
-      for (var entry in variables.entries) {
-        preparedExpression =
-            preparedExpression.replaceAll(entry.key, entry.value.toString());
-      }
-      debugPrint(
-          "Expression with variables substituted: '$preparedExpression'");
+      debugPrint("Final expression for exath: '$preparedExpression'");
 
       if (preparedExpression.isNotEmpty) {
-        Expression exp = Expression(preparedExpression);
-        var evalResult = exp.eval();
+        final ExathResult evalResult = _exathEval(
+          preparedExpression,
+          angle: isDeg ? AngleMode.deg : AngleMode.rad,
+          vars: variables,
+        );
 
-        if (evalResult != null) {
-          double result = evalResult.toDouble();
+        if (evalResult.isError) {
+          throw Exception(evalResult.error);
+        }
 
-          if (result.isFinite) {
-            if (mounted) {
-              setState(() {
-                answer = formatNumber(result);
-              });
-            }
-          } else {
-            throw Exception("Result is not finite: $result");
-          }
-        } else {
-          throw Exception("Evaluation returned null");
+        final String formatted = evalResult.isComplex
+            ? _formatComplex(evalResult.re, evalResult.im)
+            : (evalResult.re.isFinite
+                ? formatNumber(evalResult.re)
+                : throw Exception("Result is not finite: ${evalResult.re}"));
+
+        if (mounted) {
+          setState(() {
+            answer = formatted;
+          });
         }
       }
     } catch (e) {
@@ -664,11 +546,14 @@ class _CalcPageState extends ConsumerState<CalcPage>
             // For + and -, calculate percentage of left operand
             if (operator == '+' || operator == '-') {
               try {
-                Expression exp = Expression(leftExpr);
-                var evalResult = exp.eval();
+                final evalResult = _exathEval(
+                  leftExpr,
+                  angle: isDeg ? AngleMode.deg : AngleMode.rad,
+                  vars: variables,
+                );
 
-                if (evalResult != null) {
-                  double leftValue = evalResult.toDouble();
+                if (!evalResult.isError) {
+                  double leftValue = evalResult.re;
                   double percentOfLeft = leftValue * percentValue;
 
                   if (operator == '+') {
@@ -689,11 +574,14 @@ class _CalcPageState extends ConsumerState<CalcPage>
               try {
                 // Create the expression with the percentage value
                 String evalExpr = leftExpr + operator + percentValue.toString();
-                Expression exp = Expression(evalExpr);
-                var evalResult = exp.eval();
+                final evalResult = _exathEval(
+                  evalExpr,
+                  angle: isDeg ? AngleMode.deg : AngleMode.rad,
+                  vars: variables,
+                );
 
-                if (evalResult != null) {
-                  result = evalResult.toDouble();
+                if (!evalResult.isError) {
+                  result = evalResult.re;
                 } else {
                   // Fallback to simple percentage
                   result = percentValue;
@@ -1519,6 +1407,16 @@ class _CalcPageState extends ConsumerState<CalcPage>
     }
 
     return _numberFormat.format(number);
+  }
+
+  /// Formats a complex result from exath as `a + bi` (or `bi` when the real
+  /// part is ~0). exath evaluates over ℂ, so e.g. √(-4) now yields `2i`.
+  String _formatComplex(double re, double im) {
+    final String imPart = '${formatNumber(im.abs())}i';
+    if (re.abs() < 1e-12) {
+      return im < 0 ? '-$imPart' : imPart;
+    }
+    return '${formatNumber(re)} ${im < 0 ? '-' : '+'} $imPart';
   }
 
   String formatScientificForInput(String scientificNumber) {
@@ -2351,3 +2249,14 @@ class _CalcPageState extends ConsumerState<CalcPage>
 
 // Call this after formatting in setState blocks
 } // End of _CalcPageState
+
+/// Evaluate [expr] through the exath_engine plugin, binding [vars] via a session
+/// (the plugin's top-level `evaluate` is stateless).
+ExathResult _exathEval(String expr,
+    {required AngleMode angle, Map<String, double> vars = const {}}) {
+  final s = ExathSession(angleMode: angle);
+  vars.forEach((name, value) => s.setVar(name, value));
+  final r = s.eval(expr);
+  s.dispose();
+  return r;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:pro_calc/Pages/calc_page.dart';
 import 'package:pro_calc/Pages/utils_theme_provider.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:exath_engine/exath_engine.dart';
 
 Future<void> initializeApp() async {
   try {
@@ -23,6 +24,7 @@ void main() async {
   try {
     WidgetsFlutterBinding.ensureInitialized();
     await initializeApp();
+    await ensureInitialized();
 
     runApp(const ProviderScope(
       child: ProCalc(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "8.4.1"
   ansicolor:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -97,14 +97,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_assets:
-    dependency: transitive
-    description:
-      name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   collection:
     dependency: transitive
     description:
@@ -153,30 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  dart_numerics:
-    dependency: transitive
-    description:
-      name: dart_numerics
-      sha256: "47408d4890551636204851325e5649bf1a1616ebc325184c36722a1716cbaba4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.6"
-  decimal:
-    dependency: transitive
-    description:
-      name: decimal
-      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.4"
-  eval_ex:
+  exath_engine:
     dependency: "direct main"
     description:
-      name: eval_ex
-      sha256: a99e20fb004275b38f27f186718a157d4d8687e69f75b5780e6c02b9cc9e6c0d
+      name: exath_engine
+      sha256: ba5ade6ca5afa4fc585585e8a0d90f0936dc61380dc1dcccc948d1abac02b7d6
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -280,14 +256,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  function_tree:
-    dependency: "direct main"
-    description:
-      name: function_tree
-      sha256: "098f41f8c8d55952fd162cbeb709e8213a709065ab6fbebffe323701c785a259"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1"
   glob:
     dependency: transitive
     description:
@@ -304,14 +272,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.0"
-  hooks:
-    dependency: transitive
-    description:
-      name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   html:
     dependency: transitive
     description:
@@ -384,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -436,26 +404,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -464,14 +432,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -488,14 +448,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   package_config:
     dependency: transitive
     description:
@@ -532,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -616,22 +568,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  rational:
-    dependency: transitive
-    description:
-      name: rational
-      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.3"
-  record_use:
-    dependency: transitive
-    description:
-      name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   riverpod:
     dependency: transitive
     description:
@@ -801,34 +737,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: "direct dev"
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -990,5 +918,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Prevent accidental publishing to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.3 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -13,7 +13,9 @@ dependencies:
   flutter_riverpod: ^3.2.1
   provider: ^6.1.4
   intl: ^0.20.0
-  eval_ex: ^1.2.0
+  # Math engine: the exath_engine plugin from pub.dev (the exath-engine; Rust under the hood,
+  # prebuilt and bundled for every platform). No local FFI/wasm build.
+  exath_engine: ^1.0.0
 
 
   # The core Flutter framework includes Material widgets.
@@ -22,8 +24,8 @@ dependencies:
   cupertino_icons: ^1.0.2
   google_fonts: ^8.0.2
   fluentui_system_icons: ^1.1.229
-  # math_expressions: ^2.7.0 # Note: Check pub.dev for the latest version if needed. Version 2.7.0 seems custom or old, 2.4.0 is common.
-  function_tree: ^0.9.1
+  # Math evaluation is handled entirely by the exath_engine plugin (above).
+  # Removed: eval_ex, function_tree, math_expressions.
   shared_preferences: ^2.2.2
   flutter_displaymode: ^0.7.0
   font_awesome_flutter: ^11.0.0


### PR DESCRIPTION
## What
Replaces the `eval_ex` expression evaluator with the `exath_engine` Flutter plugin (v1.0.0) as Pro Calc's math engine.

## Why
`eval_ex` returns **incorrect results for more involved calculations**. exath_engine is backed by a Rust engine with a verified evaluator, so the arithmetic is actually correct. Beyond that it evaluates **complex numbers** natively (e.g. `sqrt(-4)`, which the calculator already formats), runs the **same engine on every platform** for consistent results, and replaces **two math dependencies** (`eval_ex` + `function_tree`) with one. It also opens the door to exath_engine's computer-algebra features (derivatives, integrals, solving) later.

## Changes
- `pubspec.yaml`: drop `eval_ex` and `function_tree`; add `exath_engine: ^1.0.0`
- `lib/Pages/calc_page.dart`: evaluate via `package:exath_engine` (`ExathSession` / `AngleMode` / `ExathResult`) instead of `eval_ex`'s `Expression`
- `lib/main.dart`: `await ensureInitialized()` at startup (loads the WASM module on web, no-op elsewhere)
- net **+112 / -271** lines

## Verification
- `flutter analyze`: clean
- `flutter build apk`: builds; the plugin's `libexath_engine_ffi.so` is bundled for arm64-v8a / armeabi-v7a / x86_64
